### PR TITLE
Async filters support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@ lerna-debug.log*
 !.vscode/tasks.json
 !.vscode/launch.json
 !.vscode/extensions.json
+
+database.sqlite

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ export class RbacTestController {
 
   @Get('/')
   async test1(): Promise<boolean> {
-    await this.rbac.getRole(role).can('permission', 'permission@create');
+    return await (await this.rbac.getRole(role)).can('permission', 'permission@create');
     return true;
   }
 }
@@ -216,13 +216,27 @@ export class TestFilter implements IFilterPermission {
   }
 
 }
+
+//===================== implementing async filter
+import { IFilterPermission } from 'nestjs-rbac';
+
+@Injectable()
+export class TestFilter implements IFilterPermission {
+  constructor(private readonly myService: MyService) {}
+
+  async can(params?: any[]): Promise<boolean> {
+    const myResult = await this.myService.someAsyncOperation()
+    // Do something with myResult
+    return myResult;
+  }
+}
 ```
 `ParamsFilter` services for passing arguments into particular filter:
 ```typescript
 const filter = new ParamsFilter();
 filter.setParam('filter1', some payload);
 
-const res = await rbacService.getRole('admin', filter).can(
+const res = await (await rbacService.getRole('admin', filter)).can(
   'permission1@filter1',
 );
 ```

--- a/README.md
+++ b/README.md
@@ -195,15 +195,17 @@ For creating `filter`, there is need to implement `IFilterPermission` interface,
 export const RBAC: IStorageRbac = {
   roles: ['role'],
   permissions: {
-    permission1: ['filter1'],
+    permission1: ['filter1', 'filter2'],
   },
   grants: {
     role: [
       `permission1@filter1`
+      `permission1@filter2`
     ],
   },
   filters: {
     filter1: TestFilter,
+    filter2: TestAsyncFilter,
   },
 };
 //===================== implementing filter
@@ -221,16 +223,18 @@ export class TestFilter implements IFilterPermission {
 import { IFilterPermission } from 'nestjs-rbac';
 
 @Injectable()
-export class TestFilter implements IFilterPermission {
+export class TestAsyncFilter implements IFilterPermission {
   constructor(private readonly myService: MyService) {}
 
-  async can(params?: any[]): Promise<boolean> {
+  async canAsync(params?: any[]): Promise<boolean> {
     const myResult = await this.myService.someAsyncOperation()
     // Do something with myResult
     return myResult;
   }
 }
 ```
+:warning: - A single filter can implement both `can` and `canAsync`. If you use the RBAcGuard, they will be evaluated with an **AND** condition.
+
 `ParamsFilter` services for passing arguments into particular filter:
 ```typescript
 const filter = new ParamsFilter();

--- a/package.json
+++ b/package.json
@@ -8,9 +8,9 @@
     "build": "rimraf dist && tsc -p tsconfig.build.json",
     "lint": "tslint -p tsconfig.json -c tslint.json",
     "lint:fix": "tslint -p tsconfig.json -c tslint.json --fix",
-    "test:watch": "jest --watch",
-    "test:cov": "jest --coverage",
-    "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
+    "test:watch": "jest --watch  --config ./test/jest.json",
+    "test:cov": "jest --coverage --config ./test/jest.json",
+    "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand --config ./test/jest.json",
     "test:e2e": "jest  --verbose  --config ./test/e2e/jest-e2e.json",
     "test:int": "jest  --verbose --config ./test/int/jest-int.json",
     "test": "jest --verbose --config ./test/jest.json"
@@ -41,17 +41,17 @@
     "@types/supertest": "2.0.8",
     "class-transformer": "^0.3.1",
     "class-validator": "^0.12.2",
-    "jest": "24.9.0",
+    "jest": "26.6.1",
     "prettier": "1.18.2",
     "sqlite3": "^5.0.0",
     "supertest": "4.0.2",
-    "ts-jest": "25.1.0",
+    "ts-jest": "26.4.2",
     "ts-node": "8.5.0",
     "tsc-watch": "3.0.2",
     "tsconfig-paths": "3.9.0",
     "tslint": "5.20.0",
     "typeorm": "^0.2.28",
-    "typescript": "3.6.3"
+    "typescript": "4.0.3"
   },
   "jest": {
     "moduleFileExtensions": [

--- a/src/guards/rbac.guard.ts
+++ b/src/guards/rbac.guard.ts
@@ -33,7 +33,10 @@ export class RBAcGuard implements CanActivate {
     try {
       const filter = new ParamsFilter();
       filter.setParam(RBAC_REQUEST_FILTER, { ...request });
-      return await (await this.rbacService.getRole(user.role, filter)).can(...permissions);
+      const role = await this.rbacService.getRole(user.role, filter)
+      const can = role.can(...permissions);
+      const canAsync = await role.canAsync(...permissions);
+      return can && canAsync
     } catch (e) {
       throw new ForbiddenException(e.message);
     }

--- a/src/guards/rbac.guard.ts
+++ b/src/guards/rbac.guard.ts
@@ -33,7 +33,7 @@ export class RBAcGuard implements CanActivate {
     try {
       const filter = new ParamsFilter();
       filter.setParam(RBAC_REQUEST_FILTER, { ...request });
-      return (await this.rbacService.getRole(user.role, filter)).can(...permissions);
+      return await (await this.rbacService.getRole(user.role, filter)).can(...permissions);
     } catch (e) {
       throw new ForbiddenException(e.message);
     }

--- a/src/permissions/interfaces/filter.permission.interface.ts
+++ b/src/permissions/interfaces/filter.permission.interface.ts
@@ -1,4 +1,5 @@
 export interface IFilterPermission {
   // pass only via @RBAcPermissions
-  can(params?: any[]): boolean | Promise<boolean>;
+  can?(params?: any[]): boolean;
+  canAsync?(params?: any[]): Promise<boolean>;
 }

--- a/src/permissions/interfaces/filter.permission.interface.ts
+++ b/src/permissions/interfaces/filter.permission.interface.ts
@@ -1,4 +1,4 @@
 export interface IFilterPermission {
   // pass only via @RBAcPermissions
-  can(params?: any[]): boolean;
+  can(params?: any[]): boolean | Promise<boolean>;
 }

--- a/src/role/interfaces/role.rbac.interface.ts
+++ b/src/role/interfaces/role.rbac.interface.ts
@@ -1,3 +1,3 @@
 export interface IRoleRbac {
-  can(...permissions: string[]): boolean;
+  can(...permissions: string[]): Promise<boolean>;
 }

--- a/src/role/interfaces/role.rbac.interface.ts
+++ b/src/role/interfaces/role.rbac.interface.ts
@@ -1,3 +1,4 @@
 export interface IRoleRbac {
-  can(...permissions: string[]): Promise<boolean>;
+  can(...permissions: string[]): boolean;
+  canAsync(...permissions: string[]): Promise<boolean>;
 }

--- a/test/fixtures/filters/test.async.filter.one.ts
+++ b/test/fixtures/filters/test.async.filter.one.ts
@@ -1,0 +1,11 @@
+import { IFilterPermission } from '../../../src/permissions/interfaces/filter.permission.interface';
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class TestAsyncFilterOne implements IFilterPermission {
+
+  canAsync(params?: any[]): Promise<boolean> {
+    return Promise.resolve(params[0]);
+  }
+
+}

--- a/test/fixtures/filters/test.async.filter.two.ts
+++ b/test/fixtures/filters/test.async.filter.two.ts
@@ -1,0 +1,11 @@
+import { IFilterPermission } from '../../../src/permissions/interfaces/filter.permission.interface';
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class TestAsyncFilterTwo implements IFilterPermission {
+
+  canAsync(params?: any[]): Promise<boolean> {
+    return Promise.resolve(params[0]);
+  }
+
+}

--- a/test/fixtures/storage.ts
+++ b/test/fixtures/storage.ts
@@ -1,6 +1,8 @@
 import { IStorageRbac } from '../../src/interfaces/storage.rbac.interface';
 import { TestFilterOne } from './filters/test.filter.one';
 import { TestFilterTwo } from './filters/test.filter.two';
+import { TestAsyncFilterOne } from './filters/test.async.filter.one';
+import { TestAsyncFilterTwo } from './filters/test.async.filter.two';
 import { RBAC_REQUEST_FILTER } from '../../src/constans';
 import { RequestFilter } from './filters/request.filter';
 
@@ -11,20 +13,24 @@ export const RBAC: IStorageRbac = {
     permission2: ['create', 'update', 'delete'],
     permission3: ['filter1', 'filter2', RBAC_REQUEST_FILTER],
     permission4: ['create', 'update', 'delete'],
+    permission5: ['asyncFilter1', 'asyncFilter2'],
   },
   grants: {
     admin: [
       '&user',
       'permission1',
       'permission3',
+      'permission5',
     ],
-    user: ['&userRoot', 'permission2', 'permission1@create', 'permission3@filter1'],
+    user: ['&userRoot', 'permission2', 'permission1@create', 'permission3@filter1', 'permission5@asyncFilter1'],
     userRoot: ['permission4'],
 
   },
   filters: {
     filter1: TestFilterOne,
     filter2: TestFilterTwo,
+    asyncFilter1: TestAsyncFilterOne,
+    asyncFilter2: TestAsyncFilterTwo,
     [RBAC_REQUEST_FILTER]: RequestFilter,
   },
 };

--- a/test/int/rbac/rbac.async.int.test.ts
+++ b/test/int/rbac/rbac.async.int.test.ts
@@ -34,19 +34,19 @@ describe('RBAC async service', () => {
 
     it('Should return true because admin has permissions for permission1@create',
       async () => {
-        const res = (await rbacService.getRole('admin')).can('permission1@create');
+        const res = await (await rbacService.getRole('admin')).can('permission1@create');
         expect(res).toBe(true);
       });
 
     it('Should return false because user hasn\'t permissions for permission1@update',
       async () => {
-        const res = (await rbacService.getRole('user')).can('permission1@update');
+        const res = await (await rbacService.getRole('user')).can('permission1@update');
         expect(res).toBe(false);
       });
 
     it('Should return true because user has permissions for permission1@create',
       async () => {
-        const res = (await rbacService.getRole('user')).can('permission1@create');
+        const res = await (await rbacService.getRole('user')).can('permission1@create');
         expect(res).toBe(true);
       });
 
@@ -56,19 +56,19 @@ describe('RBAC async service', () => {
 
     it('Should return true because admin extends user',
       async () => {
-        const res = (await rbacService.getRole('admin')).can('permission2@update');
+        const res = await (await rbacService.getRole('admin')).can('permission2@update');
         expect(res).toBe(true);
       });
 
     it('Should return true because user extends userRoot',
       async () => {
-        const res = (await rbacService.getRole('user')).can('permission4@create');
+        const res = await (await rbacService.getRole('user')).can('permission4@create');
         expect(res).toBe(true);
       });
 
     it('Should return false because deep extends dont work',
       async () => {
-        const res = (await rbacService.getRole('admin')).can('permission4@create');
+        const res = await (await rbacService.getRole('admin')).can('permission4@create');
         expect(res).toBe(false);
       });
 
@@ -80,7 +80,7 @@ describe('RBAC async service', () => {
       async () => {
         const filter = new ParamsFilter();
         filter.setParam('filter1', true);
-        const res = (await rbacService.getRole('admin', filter)).can(
+        const res = await (await rbacService.getRole('admin', filter)).can(
           'permission3@filter1',
         );
         expect(res).toBe(true);
@@ -93,7 +93,7 @@ describe('RBAC async service', () => {
         filter
           .setParam('filter1', true)
           .setParam('filter2', false);
-        const res = (await rbacService.getRole('admin', filter)).can(
+        const res = await (await rbacService.getRole('admin', filter)).can(
           'permission3@filter2',
           'permission3@filter1',
         );
@@ -107,7 +107,7 @@ describe('RBAC async service', () => {
           .setParam('filter2', true)
           .setParam('filter3', true);
 
-        const res = (await rbacService.getRole('admin', filter)).can(
+        const res = await (await rbacService.getRole('admin', filter)).can(
           'permission3@filter2',
           'permission3@filter1',
           'permission3@filter3',

--- a/test/int/rbac/rbac.async.int.test.ts
+++ b/test/int/rbac/rbac.async.int.test.ts
@@ -34,19 +34,19 @@ describe('RBAC async service', () => {
 
     it('Should return true because admin has permissions for permission1@create',
       async () => {
-        const res = await (await rbacService.getRole('admin')).can('permission1@create');
+        const res = (await rbacService.getRole('admin')).can('permission1@create');
         expect(res).toBe(true);
       });
 
     it('Should return false because user hasn\'t permissions for permission1@update',
       async () => {
-        const res = await (await rbacService.getRole('user')).can('permission1@update');
+        const res = (await rbacService.getRole('user')).can('permission1@update');
         expect(res).toBe(false);
       });
 
     it('Should return true because user has permissions for permission1@create',
       async () => {
-        const res = await (await rbacService.getRole('user')).can('permission1@create');
+        const res = (await rbacService.getRole('user')).can('permission1@create');
         expect(res).toBe(true);
       });
 
@@ -56,19 +56,19 @@ describe('RBAC async service', () => {
 
     it('Should return true because admin extends user',
       async () => {
-        const res = await (await rbacService.getRole('admin')).can('permission2@update');
+        const res = (await rbacService.getRole('admin')).can('permission2@update');
         expect(res).toBe(true);
       });
 
     it('Should return true because user extends userRoot',
       async () => {
-        const res = await (await rbacService.getRole('user')).can('permission4@create');
+        const res = (await rbacService.getRole('user')).can('permission4@create');
         expect(res).toBe(true);
       });
 
     it('Should return false because deep extends dont work',
       async () => {
-        const res = await (await rbacService.getRole('admin')).can('permission4@create');
+        const res = (await rbacService.getRole('admin')).can('permission4@create');
         expect(res).toBe(false);
       });
 
@@ -80,7 +80,7 @@ describe('RBAC async service', () => {
       async () => {
         const filter = new ParamsFilter();
         filter.setParam('filter1', true);
-        const res = await (await rbacService.getRole('admin', filter)).can(
+        const res = (await rbacService.getRole('admin', filter)).can(
           'permission3@filter1',
         );
         expect(res).toBe(true);
@@ -93,7 +93,7 @@ describe('RBAC async service', () => {
         filter
           .setParam('filter1', true)
           .setParam('filter2', false);
-        const res = await (await rbacService.getRole('admin', filter)).can(
+        const res = (await rbacService.getRole('admin', filter)).can(
           'permission3@filter2',
           'permission3@filter1',
         );
@@ -107,7 +107,7 @@ describe('RBAC async service', () => {
           .setParam('filter2', true)
           .setParam('filter3', true);
 
-        const res = await (await rbacService.getRole('admin', filter)).can(
+        const res = (await rbacService.getRole('admin', filter)).can(
           'permission3@filter2',
           'permission3@filter1',
           'permission3@filter3',

--- a/test/int/rbac/rbac.async.int.test.ts
+++ b/test/int/rbac/rbac.async.int.test.ts
@@ -116,6 +116,50 @@ describe('RBAC async service', () => {
         expect(res).toBe(false);
       });
 
+    describe('Async', () => {
+
+      it('Should return true because admin has the custom filter permission5@asyncFilter1',
+        async () => {
+          const filter = new ParamsFilter();
+          filter.setParam('asyncFilter1', true);
+          const res = await (await rbacService.getRole('admin', filter)).canAsync(
+            'permission5@asyncFilter1',
+          );
+          expect(res).toBe(true);
+        });
+
+      it('Should return false because admin has the custom filter ' +
+        'permission3@filter1 permission3@filter1',
+        async () => {
+          const filter = new ParamsFilter();
+          filter
+            .setParam('asyncFilter1', true)
+            .setParam('asyncFilter2', false);
+          const res = await (await rbacService.getRole('admin', filter)).canAsync(
+            'permission5@asyncFilter2',
+            'permission5@asyncFilter1',
+          );
+          expect(res).toBe(false);
+        });
+
+      it('Should return false because  of admin has the custom asyncFilter3 doesnt exist',
+        async () => {
+          const filter = new ParamsFilter();
+          filter.setParam('asyncFilter1', true)
+            .setParam('asyncFilter2', true)
+            .setParam('asyncFilter3', true);
+
+          const res = (await rbacService.getRole('admin', filter)).can(
+            'permission5@asyncFilter2',
+            'permission5@asyncFilter1',
+            'permission5@asyncFilter3',
+          );
+
+          expect(res).toBe(false);
+        });
+
+    });
+
   });
 
   afterAll(async () => {

--- a/test/int/rbac/rbac.int.test.ts
+++ b/test/int/rbac/rbac.int.test.ts
@@ -112,6 +112,50 @@ describe('RBAC service', () => {
         expect(res).toBe(false);
       });
 
+      describe('Async', () => {
+
+        it('Should return true because admin has the custom filter permission5@asyncFilter1',
+          async () => {
+            const filter = new ParamsFilter();
+            filter.setParam('asyncFilter1', true);
+            const res = await (await rbacService.getRole('admin', filter)).canAsync(
+              'permission5@asyncFilter1',
+            );
+            expect(res).toBe(true);
+          });
+
+        it('Should return false because admin has the custom filter ' +
+          'permission3@filter1 permission3@filter1',
+          async () => {
+            const filter = new ParamsFilter();
+            filter
+              .setParam('asyncFilter1', true)
+              .setParam('asyncFilter2', false);
+            const res = await (await rbacService.getRole('admin', filter)).canAsync(
+              'permission5@asyncFilter2',
+              'permission5@asyncFilter1',
+            );
+            expect(res).toBe(false);
+          });
+
+        it('Should return false because  of admin has the custom asyncFilter3 doesnt exist',
+          async () => {
+            const filter = new ParamsFilter();
+            filter.setParam('asyncFilter1', true)
+              .setParam('asyncFilter2', true)
+              .setParam('asyncFilter3', true);
+
+            const res = (await rbacService.getRole('admin', filter)).can(
+              'permission5@asyncFilter2',
+              'permission5@asyncFilter1',
+              'permission5@asyncFilter3',
+            );
+
+            expect(res).toBe(false);
+          });
+
+      });
+
   });
 
   afterAll(async () => {

--- a/test/int/rbac/rbac.int.test.ts
+++ b/test/int/rbac/rbac.int.test.ts
@@ -30,19 +30,19 @@ describe('RBAC service', () => {
 
     it('Should return true because admin has permissions for permission1@create',
       async () => {
-        const res = (await rbacService.getRole('admin')).can('permission1@create');
+        const res = await (await rbacService.getRole('admin')).can('permission1@create');
         expect(res).toBe(true);
       });
 
     it('Should return false because user hasn\'t permissions for permission1@update',
       async () => {
-        const res = (await rbacService.getRole('user')).can('permission1@update');
+        const res = await (await rbacService.getRole('user')).can('permission1@update');
         expect(res).toBe(false);
       });
 
     it('Should return true because user has permissions for permission1@create',
       async () => {
-        const res = (await rbacService.getRole('user')).can('permission1@create');
+        const res = await (await rbacService.getRole('user')).can('permission1@create');
         expect(res).toBe(true);
       });
 
@@ -52,19 +52,19 @@ describe('RBAC service', () => {
 
     it('Should return true because admin extends user',
       async () => {
-        const res = (await rbacService.getRole('admin')).can('permission2@update');
+        const res = await (await rbacService.getRole('admin')).can('permission2@update');
         expect(res).toBe(true);
       });
 
     it('Should return true because user extends userRoot',
       async () => {
-        const res = (await rbacService.getRole('user')).can('permission4@create');
+        const res = await (await rbacService.getRole('user')).can('permission4@create');
         expect(res).toBe(true);
       });
 
     it('Should return false because deep extends dont work',
       async () => {
-        const res = (await rbacService.getRole('admin')).can('permission4@create');
+        const res = await (await rbacService.getRole('admin')).can('permission4@create');
         expect(res).toBe(false);
       });
 
@@ -76,7 +76,7 @@ describe('RBAC service', () => {
       async () => {
         const filter = new ParamsFilter();
         filter.setParam('filter1', true);
-        const res = (await rbacService.getRole('admin', filter)).can(
+        const res = await (await rbacService.getRole('admin', filter)).can(
           'permission3@filter1',
         );
         expect(res).toBe(true);
@@ -89,7 +89,7 @@ describe('RBAC service', () => {
         filter
           .setParam('filter1', true)
           .setParam('filter2', false);
-        const res = (await rbacService.getRole('admin', filter)).can(
+        const res = await (await rbacService.getRole('admin', filter)).can(
           'permission3@filter2',
           'permission3@filter1',
         );
@@ -103,7 +103,7 @@ describe('RBAC service', () => {
           .setParam('filter2', true)
           .setParam('filter3', true);
 
-        const res = (await rbacService.getRole('admin', filter)).can(
+        const res = await (await rbacService.getRole('admin', filter)).can(
           'permission3@filter2',
           'permission3@filter1',
           'permission3@filter3',

--- a/test/int/rbac/rbac.int.test.ts
+++ b/test/int/rbac/rbac.int.test.ts
@@ -30,19 +30,19 @@ describe('RBAC service', () => {
 
     it('Should return true because admin has permissions for permission1@create',
       async () => {
-        const res = await (await rbacService.getRole('admin')).can('permission1@create');
+        const res = (await rbacService.getRole('admin')).can('permission1@create');
         expect(res).toBe(true);
       });
 
     it('Should return false because user hasn\'t permissions for permission1@update',
       async () => {
-        const res = await (await rbacService.getRole('user')).can('permission1@update');
+        const res = (await rbacService.getRole('user')).can('permission1@update');
         expect(res).toBe(false);
       });
 
     it('Should return true because user has permissions for permission1@create',
       async () => {
-        const res = await (await rbacService.getRole('user')).can('permission1@create');
+        const res = (await rbacService.getRole('user')).can('permission1@create');
         expect(res).toBe(true);
       });
 
@@ -52,19 +52,19 @@ describe('RBAC service', () => {
 
     it('Should return true because admin extends user',
       async () => {
-        const res = await (await rbacService.getRole('admin')).can('permission2@update');
+        const res = (await rbacService.getRole('admin')).can('permission2@update');
         expect(res).toBe(true);
       });
 
     it('Should return true because user extends userRoot',
       async () => {
-        const res = await (await rbacService.getRole('user')).can('permission4@create');
+        const res = (await rbacService.getRole('user')).can('permission4@create');
         expect(res).toBe(true);
       });
 
     it('Should return false because deep extends dont work',
       async () => {
-        const res = await (await rbacService.getRole('admin')).can('permission4@create');
+        const res = (await rbacService.getRole('admin')).can('permission4@create');
         expect(res).toBe(false);
       });
 
@@ -76,7 +76,7 @@ describe('RBAC service', () => {
       async () => {
         const filter = new ParamsFilter();
         filter.setParam('filter1', true);
-        const res = await (await rbacService.getRole('admin', filter)).can(
+        const res = (await rbacService.getRole('admin', filter)).can(
           'permission3@filter1',
         );
         expect(res).toBe(true);
@@ -89,7 +89,7 @@ describe('RBAC service', () => {
         filter
           .setParam('filter1', true)
           .setParam('filter2', false);
-        const res = await (await rbacService.getRole('admin', filter)).can(
+        const res = (await rbacService.getRole('admin', filter)).can(
           'permission3@filter2',
           'permission3@filter1',
         );
@@ -103,7 +103,7 @@ describe('RBAC service', () => {
           .setParam('filter2', true)
           .setParam('filter3', true);
 
-        const res = await (await rbacService.getRole('admin', filter)).can(
+        const res = (await rbacService.getRole('admin', filter)).can(
           'permission3@filter2',
           'permission3@filter1',
           'permission3@filter3',


### PR DESCRIPTION
refs #62 

Hello, I've introduced async filters with this attempt by ensuring to wrap any filter with a Promise (via `Promise.resolve`) so we can return `boolean` or `Promise<boolean>`. This introduces a breaking change so perhaps we can discuss if it's best to have a `canAsync` rather than modifying the existing `can` - thoughts?