### PR TITLE
Fixed E2E tests on Node.js 15 — missing `headers`, using `rawHeaders` instead

### DIFF
--- a/test/fixtures/filters/request.filter.ts
+++ b/test/fixtures/filters/request.filter.ts
@@ -1,11 +1,23 @@
-import { IFilterPermission } from '../../../src/permissions/interfaces/filter.permission.interface';
+import { IFilterPermission } from '../../../src';
 import { Injectable } from '@nestjs/common';
+
+function getRawHeader(name: string, rawHeaders: string[]): string | boolean {
+  const key = rawHeaders.indexOf(name);
+  if (key < 0) {
+    return false;
+  }
+  const value = key + 1;
+  return rawHeaders[value];
+}
 
 @Injectable()
 export class RequestFilter implements IFilterPermission {
 
   can(params?: any[]): boolean {
-    return params[0].headers['test-header'] === 'test';
+    const name = 'test-header';
+    // Fix: missing `headers`, using `rawHeaders` for fixing tests on Node.js 15
+    const header = params[0]?.headers?.[name] ?? getRawHeader(name, params[0].rawHeaders);
+    return header === 'test';
   }
 
 }


### PR DESCRIPTION
Hello, @sergey-telpuk 

This small fix for running E2E tests on Node.js 15.

Best wishes,
Sergey.