### PR TITLE
[Issue #71] - Add any & anyAsync implementation

### DIFF
--- a/src/role/interfaces/role.rbac.interface.ts
+++ b/src/role/interfaces/role.rbac.interface.ts
@@ -1,6 +1,6 @@
 export interface IRoleRbac {
-  can(...permissions: string[]): boolean;
-  canAsync(...permissions: string[]): Promise<boolean>;
+  can(...permissions: string[]): boolean
+  canAsync(...permissions: string[]): Promise<boolean>
   any(permissions: string[][]): boolean
   anyAsync(permissions: string[][]): Promise<boolean>
 }

--- a/src/role/interfaces/role.rbac.interface.ts
+++ b/src/role/interfaces/role.rbac.interface.ts
@@ -1,4 +1,6 @@
 export interface IRoleRbac {
   can(...permissions: string[]): boolean;
   canAsync(...permissions: string[]): Promise<boolean>;
+  any(permissions: string[][]): boolean
+  anyAsync(permissions: string[][]): Promise<boolean>
 }

--- a/src/role/interfaces/role.rbac.interface.ts
+++ b/src/role/interfaces/role.rbac.interface.ts
@@ -1,6 +1,6 @@
 export interface IRoleRbac {
-  can(...permissions: string[]): boolean
-  canAsync(...permissions: string[]): Promise<boolean>
-  any(...permissions: string[][]): boolean
-  anyAsync(...permissions: string[][]): Promise<boolean>
+  can(...permissions: string[]): boolean;
+  canAsync(...permissions: string[]): Promise<boolean>;
+  any(...permissions: string[][]): boolean;
+  anyAsync(...permissions: string[][]): Promise<boolean>;
 }

--- a/src/role/interfaces/role.rbac.interface.ts
+++ b/src/role/interfaces/role.rbac.interface.ts
@@ -1,6 +1,6 @@
 export interface IRoleRbac {
   can(...permissions: string[]): boolean
   canAsync(...permissions: string[]): Promise<boolean>
-  any(permissions: string[][]): boolean
-  anyAsync(permissions: string[][]): Promise<boolean>
+  any(...permissions: string[][]): boolean
+  anyAsync(...permissions: string[][]): Promise<boolean>
 }

--- a/src/role/role.rbac.ts
+++ b/src/role/role.rbac.ts
@@ -1,7 +1,7 @@
-import { Injectable } from '@nestjs/common'
-import { IRoleRbac } from './interfaces/role.rbac.interface'
-import { IFilterPermission } from '../permissions/interfaces/filter.permission.interface'
-import { IParamsFilter } from '../params-filter/interfaces/params.filter.interface'
+import { Injectable } from '@nestjs/common';
+import { IRoleRbac } from './interfaces/role.rbac.interface';
+import { IFilterPermission } from '../permissions/interfaces/filter.permission.interface';
+import { IParamsFilter } from '../params-filter/interfaces/params.filter.interface';
 
 @Injectable()
 export class RoleRbac implements IRoleRbac {
@@ -13,44 +13,44 @@ export class RoleRbac implements IRoleRbac {
   ) {}
 
   async canAsync (...permissions: string[]): Promise<boolean> {
-    return this.checkPermissions<Promise<boolean>>(permissions, 'canAsync')
+    return this.checkPermissions<Promise<boolean>>(permissions, 'canAsync');
   }
 
   can (...permissions: string[]): boolean {
-    return this.checkPermissions<boolean>(permissions, 'can')
+    return this.checkPermissions<boolean>(permissions, 'can');
   }
 
   any (...permissions: string[][]): boolean {
     // loop through the list of permission list
     return (
       permissions
-        .map(async permission => {
+        .map(permission => {
           // check each of the permission list
-          return this.can(...permission)
+          return this.can(...permission);
         })
         // any permission list is true, then return true as result
         .some(result => result)
-    )
+    );
   }
 
   async anyAsync (...permissions: string[][]): Promise<boolean> {
     return (
       await Promise.all(
         permissions.map(async permission => {
-          return this.canAsync(...permission)
+          return await this.canAsync(...permission);
         }),
       )
-    ).some(result => result)
+    ).some(result => result);
   }
 
   private checkPermissions<T> (permissions, methodName): T {
     if (!permissions.length) {
-      return false as any
+      return false as any;
     }
     // check grant
     for (const permission of permissions) {
       if (!this.grant.includes(permission)) {
-        return false as any
+        return false as any;
       }
     }
 
@@ -58,14 +58,14 @@ export class RoleRbac implements IRoleRbac {
     for (const permission of permissions) {
       // check particular permission [permission@action]
       if (this.grant.includes(permission) && permission.includes('@')) {
-        const filter: string = permission.split('@')[1]
-        const filterService: IFilterPermission = this.filters[filter]
+        const filter: string = permission.split('@')[1];
+        const filterService: IFilterPermission = this.filters[filter];
         if (filterService) {
           return (
             filterService?.[methodName]?.(
               this.paramsFilter ? this.paramsFilter.getParam(filter) : null,
             ) ?? true
-          )
+          );
         }
       }
       // check particular permission [permission]
@@ -79,12 +79,12 @@ export class RoleRbac implements IRoleRbac {
               this.filters[filter]?.[methodName]?.(
                 this.paramsFilter ? this.paramsFilter.getParam(filter) : null,
               ) ?? true
-            )
+            );
           }
         }
       }
     }
 
-    return true as any
+    return true as any;
   }
 }

--- a/src/role/role.rbac.ts
+++ b/src/role/role.rbac.ts
@@ -20,7 +20,7 @@ export class RoleRbac implements IRoleRbac {
     return this.checkPermissions<boolean>(permissions, 'can')
   }
 
-  any (permissions: string[][]): boolean {
+  any (...permissions: string[][]): boolean {
     // loop through the list of permission list
     return (
       permissions
@@ -33,7 +33,7 @@ export class RoleRbac implements IRoleRbac {
     )
   }
 
-  async anyAsync (permissions: string[][]): Promise<boolean> {
+  async anyAsync (...permissions: string[][]): Promise<boolean> {
     return (
       await Promise.all(
         permissions.map(async permission => {

--- a/src/role/role.rbac.ts
+++ b/src/role/role.rbac.ts
@@ -1,70 +1,90 @@
-import { Injectable } from '@nestjs/common';
-import { IRoleRbac } from './interfaces/role.rbac.interface';
-import { IFilterPermission } from '../permissions/interfaces/filter.permission.interface';
-import { IParamsFilter } from '../params-filter/interfaces/params.filter.interface';
+import { Injectable } from '@nestjs/common'
+import { IRoleRbac } from './interfaces/role.rbac.interface'
+import { IFilterPermission } from '../permissions/interfaces/filter.permission.interface'
+import { IParamsFilter } from '../params-filter/interfaces/params.filter.interface'
 
 @Injectable()
 export class RoleRbac implements IRoleRbac {
-
-  constructor(
+  constructor (
     private readonly role: string,
     private readonly grant: string[],
     private readonly filters: object,
     private readonly paramsFilter?: IParamsFilter,
-  ) {
+  ) {}
+
+  async canAsync (...permissions: string[]): Promise<boolean> {
+    return this.checkPermissions<Promise<boolean>>(permissions, 'canAsync')
   }
 
-  async canAsync(...permissions: string[]): Promise<boolean> {
-    return this.checkPermissions<Promise<boolean>>(permissions, 'canAsync');
+  can (...permissions: string[]): boolean {
+    return this.checkPermissions<boolean>(permissions, 'can')
   }
 
-  can(...permissions: string[]): boolean {
-    return this.checkPermissions<boolean>(permissions, 'can');
+  any (permissions: string[][]): boolean {
+    // loop through the list of permission list
+    return (
+      permissions
+        .map(async permission => {
+          // check each of the permission list
+          return this.can(...permission)
+        })
+        // any permission list is true, then return true as result
+        .some(result => result)
+    )
   }
 
-  private checkPermissions<T>(permissions, methodName): T {
+  async anyAsync (permissions: string[][]): Promise<boolean> {
+    return (
+      await Promise.all(
+        permissions.map(async permission => {
+          return this.canAsync(...permission)
+        }),
+      )
+    ).some(result => result)
+  }
+
+  private checkPermissions<T> (permissions, methodName): T {
     if (!permissions.length) {
-      return (false as any);
+      return false as any
     }
     // check grant
     for (const permission of permissions) {
       if (!this.grant.includes(permission)) {
-        return (false as any);
+        return false as any
       }
     }
 
     // check custom filter
     for (const permission of permissions) {
       // check particular permission [permission@action]
-      if (
-        this.grant.includes(permission)
-        && permission.includes('@')
-      ) {
-        const filter: string = permission.split('@')[1];
-        const filterService: IFilterPermission = this.filters[filter];
+      if (this.grant.includes(permission) && permission.includes('@')) {
+        const filter: string = permission.split('@')[1]
+        const filterService: IFilterPermission = this.filters[filter]
         if (filterService) {
-          return filterService?.[methodName]?.(
-            this.paramsFilter ? this.paramsFilter.getParam(filter) : null,
-          ) ?? true;
+          return (
+            filterService?.[methodName]?.(
+              this.paramsFilter ? this.paramsFilter.getParam(filter) : null,
+            ) ?? true
+          )
         }
       }
       // check particular permission [permission]
-      if (this.grant.includes(permission)
-        && !permission.includes('@')) {
-
+      if (this.grant.includes(permission) && !permission.includes('@')) {
         for (const filter in this.filters) {
           if (
             this.filters.hasOwnProperty(filter) &&
             this.grant.includes(`${permission}@${filter}`)
           ) {
-            return this.filters[filter]?.[methodName]?.(
-              this.paramsFilter ? this.paramsFilter.getParam(filter) : null,
-            ) ?? true;
+            return (
+              this.filters[filter]?.[methodName]?.(
+                this.paramsFilter ? this.paramsFilter.getParam(filter) : null,
+              ) ?? true
+            )
           }
         }
       }
     }
 
-    return (true as any);
+    return true as any
   }
 }

--- a/test/int/rbac/rbac.async.int.test.ts
+++ b/test/int/rbac/rbac.async.int.test.ts
@@ -13,16 +13,14 @@ describe('RBAC async service', () => {
   let rbacService: RbacService;
 
   beforeAll(async () => {
-    const moduleFixture = await Test.createTestingModule(
-      {
-        imports: [
-          RBAcModule
-            .useCache(RbacCache, {KEY: 'RBAC', TTL: 400})
-            .forDynamic(AsyncService),
-        ],
-        controllers: [],
-      },
-    ).compile();
+    const moduleFixture = await Test.createTestingModule({
+      imports: [
+        RBAcModule.useCache(RbacCache, { KEY: 'RBAC', TTL: 400 }).forDynamic(
+          AsyncService,
+        ),
+      ],
+      controllers: [],
+    }).compile();
 
     app = moduleFixture.createNestApplication();
     rbacService = moduleFixture.get(RbacService);
@@ -31,135 +29,190 @@ describe('RBAC async service', () => {
   });
 
   describe('Permission', () => {
+    it('Should return true because admin has permissions for permission1@create', async () => {
+      const res = (await rbacService.getRole('admin')).can('permission1@create');
+      expect(res).toBe(true);
+    });
 
-    it('Should return true because admin has permissions for permission1@create',
-      async () => {
-        const res = (await rbacService.getRole('admin')).can('permission1@create');
-        expect(res).toBe(true);
-      });
+    it("Should return false because user hasn't permissions for permission1@update", async () => {
+      const res = (await rbacService.getRole('user')).can('permission1@update');
+      expect(res).toBe(false);
+    });
 
-    it('Should return false because user hasn\'t permissions for permission1@update',
-      async () => {
-        const res = (await rbacService.getRole('user')).can('permission1@update');
-        expect(res).toBe(false);
-      });
+    it('Should return true because user has permissions for permission1@create', async () => {
+      const res = (await rbacService.getRole('user')).can('permission1@create');
+      expect(res).toBe(true);
+    });
 
-    it('Should return true because user has permissions for permission1@create',
-      async () => {
-        const res = (await rbacService.getRole('user')).can('permission1@create');
-        expect(res).toBe(true);
-      });
+    it('Should return true because user has at least 1 permission for permission1@create', async () => {
+      const res = (await rbacService.getRole('user')).any(
+        ['permission1@create'],
+        ['permission1@update'],
+      );
+      expect(res).toBe(true);
+    });
 
+    it('Should return false because user does not exist permissions for both permission1@update and permission1@delete', async () => {
+      const res = (await rbacService.getRole('user')).any(
+        ['permission1@update'],
+        ['permission1@delete'],
+      );
+      expect(res).toBe(false);
+    });
   });
 
   describe('Extends', () => {
+    it('Should return true because admin extends user', async () => {
+      const res = (await rbacService.getRole('admin')).can('permission2@update');
+      expect(res).toBe(true);
+    });
 
-    it('Should return true because admin extends user',
-      async () => {
-        const res = (await rbacService.getRole('admin')).can('permission2@update');
-        expect(res).toBe(true);
-      });
+    it('Should return true because user extends userRoot', async () => {
+      const res = (await rbacService.getRole('user')).can('permission4@create');
+      expect(res).toBe(true);
+    });
 
-    it('Should return true because user extends userRoot',
-      async () => {
-        const res = (await rbacService.getRole('user')).can('permission4@create');
-        expect(res).toBe(true);
-      });
+    it('Should return false because deep extends dont work', async () => {
+      const res = (await rbacService.getRole('admin')).can('permission4@create');
+      expect(res).toBe(false);
+    });
 
-    it('Should return false because deep extends dont work',
-      async () => {
-        const res = (await rbacService.getRole('admin')).can('permission4@create');
-        expect(res).toBe(false);
-      });
+    it('Should return true because at least 1 permission extended by user to admin', async () => {
+      const res = (await rbacService.getRole('admin')).any(
+        ['permission2@update'],
+        ['permission4@create'],
+      );
+      expect(res).toBe(true);
+    });
 
+    it('Should return false because neither of permissions extended to admin', async () => {
+      const res = (await rbacService.getRole('admin')).any(
+        ['permission4@create'],
+        ['permission4@update'],
+      );
+      expect(res).toBe(false);
+    });
   });
 
   describe('Filters', () => {
+    it('Should return true because admin has the custom filter permission3@filter1', async () => {
+      const filter = new ParamsFilter();
+      filter.setParam('filter1', true);
+      const res = (await rbacService.getRole('admin', filter)).can(
+        'permission3@filter1',
+      );
+      expect(res).toBe(true);
+    });
 
-    it('Should return true because admin has the custom filter permission3@filter1',
+    it(
+      'Should return false because admin has the custom filter ' +
+        'permission3@filter1 permission3@filter1',
       async () => {
         const filter = new ParamsFilter();
-        filter.setParam('filter1', true);
+        filter.setParam('filter1', true).setParam('filter2', false);
         const res = (await rbacService.getRole('admin', filter)).can(
+          'permission3@filter2',
           'permission3@filter1',
+        );
+        expect(res).toBe(false);
+      },
+    );
+
+    it('Should return false because admin has the custom filter3 doesnt exist', async () => {
+      const filter = new ParamsFilter();
+      filter
+        .setParam('filter1', true)
+        .setParam('filter2', true)
+        .setParam('filter3', true);
+
+      const res = (await rbacService.getRole('admin', filter)).can(
+        'permission3@filter2',
+        'permission3@filter1',
+        'permission3@filter3',
+      );
+
+      expect(res).toBe(false);
+    });
+
+    it('Should return true because admin has at least 1 filter permission3@filter1', async () => {
+      const filter = new ParamsFilter();
+      filter.setParam('filter1', true).setParam('filter2', false);
+      const res = (await rbacService.getRole('admin', filter)).any(
+        ['permission3@filter1'],
+        ['permission3@filter2'],
+      );
+      expect(res).toBe(true);
+    });
+
+    it('Should return false because admin has neither of the permission filters', async () => {
+      const filter = new ParamsFilter();
+      filter.setParam('filter1', false).setParam('filter2', false);
+      const res = (await rbacService.getRole('admin', filter)).any(
+        ['permission3@filter1'],
+        ['permission3@filter2'],
+      );
+      expect(res).toBe(false);
+    });
+
+    describe('Async', () => {
+      it('Should return true because admin has the custom filter permission5@asyncFilter1', async () => {
+        const filter = new ParamsFilter();
+        filter.setParam('asyncFilter1', true);
+        const res = await (await rbacService.getRole('admin', filter)).canAsync(
+          'permission5@asyncFilter1',
         );
         expect(res).toBe(true);
       });
 
-    it('Should return false because admin has the custom filter ' +
-      'permission3@filter1 permission3@filter1',
-      async () => {
+      it('Should return true because admin has at least 1 custom filter permission5@asyncFilter1', async () => {
+        const filter = new ParamsFilter();
+        filter.setParam('asyncFilter1', true).setParam('asyncFilter2', false);
+        const res = await (await rbacService.getRole('admin', filter)).anyAsync(
+          ['permission5@asyncFilter1'],
+          ['permission5@asyncFilter2'],
+        );
+        expect(res).toBe(true);
+      });
+
+      it(
+        'Should return false because admin has the custom filter ' +
+          'permission3@filter1 permission3@filter1',
+        async () => {
+          const filter = new ParamsFilter();
+          filter.setParam('asyncFilter1', true).setParam('asyncFilter2', false);
+          const res = await (
+            await rbacService.getRole('admin', filter)
+          ).canAsync('permission5@asyncFilter2', 'pewrmission5@asyncFilter1');
+          expect(res).toBe(false);
+        },
+      );
+
+      it('Should return false because admin has neither of the custom permission', async () => {
+        const filter = new ParamsFilter();
+        filter.setParam('asyncFilter1', false).setParam('asyncFilter2', false);
+        const res = await (await rbacService.getRole('admin', filter)).anyAsync(
+          ['permission5@asyncFilter2'],
+          ['permission5@asyncFilter1'],
+        );
+        expect(res).toBe(false);
+      });
+
+      it('Should return false because  of admin has the custom asyncFilter3 doesnt exist', async () => {
         const filter = new ParamsFilter();
         filter
-          .setParam('filter1', true)
-          .setParam('filter2', false);
-        const res = (await rbacService.getRole('admin', filter)).can(
-          'permission3@filter2',
-          'permission3@filter1',
-        );
-        expect(res).toBe(false);
-      });
-
-    it('Should return false because  of admin has the custom filter3 doesnt exist',
-      async () => {
-        const filter = new ParamsFilter();
-        filter.setParam('filter1', true)
-          .setParam('filter2', true)
-          .setParam('filter3', true);
+          .setParam('asyncFilter1', true)
+          .setParam('asyncFilter2', true)
+          .setParam('asyncFilter3', true);
 
         const res = (await rbacService.getRole('admin', filter)).can(
-          'permission3@filter2',
-          'permission3@filter1',
-          'permission3@filter3',
+          'permission5@asyncFilter2',
+          'permission5@asyncFilter1',
+          'permission5@asyncFilter3',
         );
 
         expect(res).toBe(false);
       });
-
-    describe('Async', () => {
-
-      it('Should return true because admin has the custom filter permission5@asyncFilter1',
-        async () => {
-          const filter = new ParamsFilter();
-          filter.setParam('asyncFilter1', true);
-          const res = await (await rbacService.getRole('admin', filter)).canAsync(
-            'permission5@asyncFilter1',
-          );
-          expect(res).toBe(true);
-        });
-
-      it('Should return false because admin has the custom filter ' +
-        'permission3@filter1 permission3@filter1',
-        async () => {
-          const filter = new ParamsFilter();
-          filter
-            .setParam('asyncFilter1', true)
-            .setParam('asyncFilter2', false);
-          const res = await (await rbacService.getRole('admin', filter)).canAsync(
-            'permission5@asyncFilter2',
-            'permission5@asyncFilter1',
-          );
-          expect(res).toBe(false);
-        });
-
-      it('Should return false because  of admin has the custom asyncFilter3 doesnt exist',
-        async () => {
-          const filter = new ParamsFilter();
-          filter.setParam('asyncFilter1', true)
-            .setParam('asyncFilter2', true)
-            .setParam('asyncFilter3', true);
-
-          const res = (await rbacService.getRole('admin', filter)).can(
-            'permission5@asyncFilter2',
-            'permission5@asyncFilter1',
-            'permission5@asyncFilter3',
-          );
-
-          expect(res).toBe(false);
-        });
-
     });
-
   });
 
   afterAll(async () => {

--- a/test/int/rbac/rbac.int.test.ts
+++ b/test/int/rbac/rbac.int.test.ts
@@ -5,20 +5,15 @@ import { Test } from '@nestjs/testing';
 import { RBAC } from '../../fixtures/storage';
 import { ParamsFilter } from '../../../src/params-filter/params.filter';
 
-
 describe('RBAC service', () => {
   let app: INestApplication;
   let rbacService: RbacService;
 
   beforeAll(async () => {
-    const moduleFixture = await Test.createTestingModule(
-      {
-        imports: [
-          RBAcModule.forRoot(RBAC),
-        ],
-        controllers: [],
-      },
-    ).compile();
+    const moduleFixture = await Test.createTestingModule({
+      imports: [RBAcModule.forRoot(RBAC)],
+      controllers: [],
+    }).compile();
 
     app = moduleFixture.createNestApplication();
     rbacService = moduleFixture.get(RbacService);
@@ -27,135 +22,190 @@ describe('RBAC service', () => {
   });
 
   describe('Permission', () => {
+    it('Should return true because admin has permissions for permission1@create', async () => {
+      const res = (await rbacService.getRole('admin')).can('permission1@create');
+      expect(res).toBe(true);
+    });
 
-    it('Should return true because admin has permissions for permission1@create',
-      async () => {
-        const res = (await rbacService.getRole('admin')).can('permission1@create');
-        expect(res).toBe(true);
-      });
+    it("Should return false because user hasn't permissions for permission1@update", async () => {
+      const res = (await rbacService.getRole('user')).can('permission1@update');
+      expect(res).toBe(false);
+    });
 
-    it('Should return false because user hasn\'t permissions for permission1@update',
-      async () => {
-        const res = (await rbacService.getRole('user')).can('permission1@update');
-        expect(res).toBe(false);
-      });
+    it('Should return true because user has permissions for permission1@create', async () => {
+      const res = (await rbacService.getRole('user')).can('permission1@create');
+      expect(res).toBe(true);
+    });
 
-    it('Should return true because user has permissions for permission1@create',
-      async () => {
-        const res = (await rbacService.getRole('user')).can('permission1@create');
-        expect(res).toBe(true);
-      });
+    it('Should return true because user has at least 1 permission for permission1@create', async () => {
+      const res = (await rbacService.getRole('user')).any(
+        ['permission1@create'],
+        ['permission1@update'],
+      );
+      expect(res).toBe(true);
+    });
 
+    it('Should return false because user does not exist permissions for both permission1@update and permission1@delete', async () => {
+      const res = (await rbacService.getRole('user')).any(
+        ['permission1@update'],
+        ['permission1@delete'],
+      );
+      expect(res).toBe(false);
+    });
   });
 
   describe('Extends', () => {
+    it('Should return true because admin extends user', async () => {
+      const res = (await rbacService.getRole('admin')).can('permission2@update');
+      expect(res).toBe(true);
+    });
 
-    it('Should return true because admin extends user',
-      async () => {
-        const res = (await rbacService.getRole('admin')).can('permission2@update');
-        expect(res).toBe(true);
-      });
+    it('Should return true because user extends userRoot', async () => {
+      const res = (await rbacService.getRole('user')).can('permission4@create');
+      expect(res).toBe(true);
+    });
 
-    it('Should return true because user extends userRoot',
-      async () => {
-        const res = (await rbacService.getRole('user')).can('permission4@create');
-        expect(res).toBe(true);
-      });
+    it('Should return false because deep extends dont work', async () => {
+      const res = (await rbacService.getRole('admin')).can('permission4@create');
+      expect(res).toBe(false);
+    });
 
-    it('Should return false because deep extends dont work',
-      async () => {
-        const res = (await rbacService.getRole('admin')).can('permission4@create');
-        expect(res).toBe(false);
-      });
+    it('Should return true because at least 1 permission extended by user to admin', async () => {
+      const res = (await rbacService.getRole('admin')).any(
+        ['permission2@update'],
+        ['permission4@create'],
+      );
+      expect(res).toBe(true);
+    });
 
+    it('Should return false because neither of permissions extended to admin', async () => {
+      const res = (await rbacService.getRole('admin')).any(
+        ['permission4@create'],
+        ['permission4@update'],
+      );
+      expect(res).toBe(false);
+    });
   });
 
   describe('Filters', () => {
+    it('Should return true because admin has the custom filter permission3@filter1', async () => {
+      const filter = new ParamsFilter();
+      filter.setParam('filter1', true);
+      const res = (await rbacService.getRole('admin', filter)).can(
+        'permission3@filter1',
+      );
+      expect(res).toBe(true);
+    });
 
-    it('Should return true because admin has the custom filter permission3@filter1',
+    it(
+      'Should return false because admin has the custom filter ' +
+        'permission3@filter1 permission3@filter1',
       async () => {
         const filter = new ParamsFilter();
-        filter.setParam('filter1', true);
+        filter.setParam('filter1', true).setParam('filter2', false);
         const res = (await rbacService.getRole('admin', filter)).can(
+          'permission3@filter2',
           'permission3@filter1',
+        );
+        expect(res).toBe(false);
+      },
+    );
+
+    it('Should return false because  of admin has the custom filter3 doesnt exist', async () => {
+      const filter = new ParamsFilter();
+      filter
+        .setParam('filter1', true)
+        .setParam('filter2', true)
+        .setParam('filter3', true);
+
+      const res = (await rbacService.getRole('admin', filter)).can(
+        'permission3@filter2',
+        'permission3@filter1',
+        'permission3@filter3',
+      );
+
+      expect(res).toBe(false);
+    });
+
+    it('Should return true because admin has at least 1 filter permission3@filter1', async () => {
+      const filter = new ParamsFilter();
+      filter.setParam('filter1', true).setParam('filter2', false);
+      const res = (await rbacService.getRole('admin', filter)).any(
+        ['permission3@filter1'],
+        ['permission3@filter2'],
+      );
+      expect(res).toBe(true);
+    });
+
+    it('Should return false because admin has neither of the permission filters', async () => {
+      const filter = new ParamsFilter();
+      filter.setParam('filter1', false).setParam('filter2', false);
+      const res = (await rbacService.getRole('admin', filter)).any(
+        ['permission3@filter1'],
+        ['permission3@filter2'],
+      );
+      expect(res).toBe(false);
+    });
+
+    describe('Async', () => {
+      it('Should return true because admin has the custom filter permission5@asyncFilter1', async () => {
+        const filter = new ParamsFilter();
+        filter.setParam('asyncFilter1', true);
+        const res = await (await rbacService.getRole('admin', filter)).canAsync(
+          'permission5@asyncFilter1',
         );
         expect(res).toBe(true);
       });
 
-    it('Should return false because admin has the custom filter ' +
-      'permission3@filter1 permission3@filter1',
-      async () => {
+      it('Should return true because admin has at least 1 custom filter permission5@asyncFilter1', async () => {
+        const filter = new ParamsFilter();
+        filter.setParam('asyncFilter1', true).setParam('asyncFilter2', false);
+        const res = await (await rbacService.getRole('admin', filter)).anyAsync(
+          ['permission5@asyncFilter1'],
+          ['permission5@asyncFilter2'],
+        );
+        expect(res).toBe(true);
+      });
+
+      it(
+        'Should return false because admin has the custom filter ' +
+          'permission3@filter1 permission3@filter1',
+        async () => {
+          const filter = new ParamsFilter();
+          filter.setParam('asyncFilter1', true).setParam('asyncFilter2', false);
+          const res = await (
+            await rbacService.getRole('admin', filter)
+          ).canAsync('permission5@asyncFilter2', 'permission5@asyncFilter1');
+          expect(res).toBe(false);
+        },
+      );
+
+      it('Should return false because admin has neither of the custom permission', async () => {
+        const filter = new ParamsFilter();
+        filter.setParam('asyncFilter1', false).setParam('asyncFilter2', false);
+        const res = await (await rbacService.getRole('admin', filter)).anyAsync(
+          ['permission5@asyncFilter2'],
+          ['permission5@asyncFilter1'],
+        );
+        expect(res).toBe(false);
+      });
+
+      it('Should return false because admin has the custom asyncFilter3 doesnt exist', async () => {
         const filter = new ParamsFilter();
         filter
-          .setParam('filter1', true)
-          .setParam('filter2', false);
-        const res = (await rbacService.getRole('admin', filter)).can(
-          'permission3@filter2',
-          'permission3@filter1',
-        );
-        expect(res).toBe(false);
-      });
-
-    it('Should return false because  of admin has the custom filter3 doesnt exist',
-      async () => {
-        const filter = new ParamsFilter();
-        filter.setParam('filter1', true)
-          .setParam('filter2', true)
-          .setParam('filter3', true);
+          .setParam('asyncFilter1', true)
+          .setParam('asyncFilter2', true)
+          .setParam('asyncFilter3', true);
 
         const res = (await rbacService.getRole('admin', filter)).can(
-          'permission3@filter2',
-          'permission3@filter1',
-          'permission3@filter3',
+          'permission5@asyncFilter2',
+          'permission5@asyncFilter1',
+          'permission5@asyncFilter3',
         );
 
         expect(res).toBe(false);
       });
-
-      describe('Async', () => {
-
-        it('Should return true because admin has the custom filter permission5@asyncFilter1',
-          async () => {
-            const filter = new ParamsFilter();
-            filter.setParam('asyncFilter1', true);
-            const res = await (await rbacService.getRole('admin', filter)).canAsync(
-              'permission5@asyncFilter1',
-            );
-            expect(res).toBe(true);
-          });
-
-        it('Should return false because admin has the custom filter ' +
-          'permission3@filter1 permission3@filter1',
-          async () => {
-            const filter = new ParamsFilter();
-            filter
-              .setParam('asyncFilter1', true)
-              .setParam('asyncFilter2', false);
-            const res = await (await rbacService.getRole('admin', filter)).canAsync(
-              'permission5@asyncFilter2',
-              'permission5@asyncFilter1',
-            );
-            expect(res).toBe(false);
-          });
-
-        it('Should return false because  of admin has the custom asyncFilter3 doesnt exist',
-          async () => {
-            const filter = new ParamsFilter();
-            filter.setParam('asyncFilter1', true)
-              .setParam('asyncFilter2', true)
-              .setParam('asyncFilter3', true);
-
-            const res = (await rbacService.getRole('admin', filter)).can(
-              'permission5@asyncFilter2',
-              'permission5@asyncFilter1',
-              'permission5@asyncFilter3',
-            );
-
-            expect(res).toBe(false);
-          });
-
-      });
-
+    });
   });
 
   afterAll(async () => {


### PR DESCRIPTION
Initial draft PR on any() & anyAysnc(), including multiple permissions array as arguments. If any of the permission list returns true,  then it returns true.

Another solution could be method overloading on the arguments which is not discussed. I can make that version but the interface must change to support.

For example:
```
- can(...permissions: string[]) : boolean {}
- can(...permissions: string[][]) : boolean {}
- canAsync(...permissions: string[]) : Promise<boolean> {}
- canAsync(...permissions: string[][]) : Promise<boolean> {}
```