### PR TITLE
updated forDynamic typings to allow parameters in rbac param constructor

### DIFF
--- a/src/rbac.module.ts
+++ b/src/rbac.module.ts
@@ -57,8 +57,8 @@ export class RBAcModule implements OnApplicationBootstrap {
         );
     }
 
-    static forDynamic(
-        rbac: new () => IDynamicStorageRbac,
+    static forDynamic<T extends new (...args: any[]) => IDynamicStorageRbac>(
+        rbac: T,
         providers?: any[],
         imports?: any[],
     ): DynamicModule {


### PR DESCRIPTION
to fix #83 
```
static forDynamic<T extends new (...args: any[]) => IDynamicStorageRbac>(
        rbac: T,
        providers?: any[],
        imports?: any[],
    ): DynamicModule {..}
```